### PR TITLE
`possible_motif_types` to accelerate zetafold with motifs (hopefully dramatically!)

### DIFF
--- a/zetafold/util/wrapped_array.py
+++ b/zetafold/util/wrapped_array.py
@@ -15,6 +15,7 @@ class WrappedArray:
 
 ##################################################################################################
 def initialize_matrix( N, val = None ):
+    assert( not isinstance(val,list ) ) # causes issue with references to same list.
     X = WrappedArray( N )
     for i in range( N ):
         X[ i ] = WrappedArray( N )


### PR DESCRIPTION
- [ ] Move identification of motifs out of `recursions.py` into an initialization step.
- [ ] Identify sequence segments that might be in a motif one time [O(N)], and reuse.
- [ ] make use of `possible_base_pair_types` so that hairpin and internal loop identification take O(N) and O(N^2) and do not repeat work.
 